### PR TITLE
Add GUI version of guessing game

### DIFF
--- a/randomStuff/cGame/Makefile
+++ b/randomStuff/cGame/Makefile
@@ -1,0 +1,20 @@
+CC=gcc
+
+all: guess
+
+# build terminal version
+guess: guess.c
+	$(CC) guess.c -o guess
+
+# build GUI version (requires GTK 3)
+# run `make gui` or `make guess_gui` to build it
+
+guess_gui: guess_gui.c
+	$(CC) guess_gui.c -o guess_gui $(shell pkg-config --cflags --libs gtk+-3.0)
+
+gui: guess_gui
+
+clean:
+	rm -f guess guess_gui
+
+.PHONY: all gui clean

--- a/randomStuff/cGame/README.md
+++ b/randomStuff/cGame/README.md
@@ -1,0 +1,20 @@
+# cGame GUI
+
+This folder contains a simple number guessing game in C.
+
+- `guess.c` - terminal version
+- `guess_gui.c` - GTK-based GUI version
+
+## Building
+
+To build the GUI version you need GTK 3 development libraries.
+
+```
+# compile terminal version
+gcc guess.c -o guess
+
+# compile GUI version (requires gtk3)
+gcc guess_gui.c -o guess_gui $(pkg-config --cflags --libs gtk+-3.0)
+```
+
+Run `./guess_gui` to play using the GUI.

--- a/randomStuff/cGame/README.md
+++ b/randomStuff/cGame/README.md
@@ -7,13 +7,21 @@ This folder contains a simple number guessing game in C.
 
 ## Building
 
-To build the GUI version you need GTK 3 development libraries.
+You can use the included `Makefile` for a simpler build process:
 
 ```
-# compile terminal version
+make        # build the terminal version (./guess)
+make gui    # build the GUI version (requires GTK 3)
+make clean  # remove generated binaries
+```
+
+If you prefer to compile manually, use:
+
+```
+# terminal version
 gcc guess.c -o guess
 
-# compile GUI version (requires gtk3)
+# GUI version (requires gtk3)
 gcc guess_gui.c -o guess_gui $(pkg-config --cflags --libs gtk+-3.0)
 ```
 

--- a/randomStuff/cGame/guess.c
+++ b/randomStuff/cGame/guess.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int main(void) {
+    srand((unsigned)time(NULL));
+    int target = rand() % 100 + 1;
+    int guess = 0;
+    int attempts = 0;
+
+    printf("Guess a number between 1 and 100\n");
+
+    while (1) {
+        printf("Enter guess: ");
+        if (scanf("%d", &guess) != 1) {
+            printf("Invalid input. Exiting.\n");
+            return 1;
+        }
+        attempts++;
+        if (guess < target) {
+            printf("Too low!\n");
+        } else if (guess > target) {
+            printf("Too high!\n");
+        } else {
+            printf("Correct! You guessed in %d attempts.\n", attempts);
+            break;
+        }
+    }
+
+    return 0;
+}

--- a/randomStuff/cGame/guess_gui.c
+++ b/randomStuff/cGame/guess_gui.c
@@ -1,0 +1,51 @@
+#include <gtk/gtk.h>
+#include <stdlib.h>
+#include <time.h>
+
+static int target;
+static int attempts = 0;
+static GtkWidget *entry;
+static GtkWidget *label;
+
+static void on_guess_clicked(GtkButton *button, gpointer user_data) {
+    const char *text = gtk_entry_get_text(GTK_ENTRY(entry));
+    int guess = atoi(text);
+    attempts++;
+    char buf[128];
+    if (guess < target) {
+        snprintf(buf, sizeof(buf), "Too low!");
+    } else if (guess > target) {
+        snprintf(buf, sizeof(buf), "Too high!");
+    } else {
+        snprintf(buf, sizeof(buf), "Correct! You guessed in %d attempts.", attempts);
+        gtk_widget_set_sensitive(GTK_WIDGET(button), FALSE);
+    }
+    gtk_label_set_text(GTK_LABEL(label), buf);
+}
+
+int main(int argc, char *argv[]) {
+    gtk_init(&argc, &argv);
+    srand((unsigned)time(NULL));
+    target = rand() % 100 + 1;
+
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Guessing Game");
+    g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+    gtk_container_add(GTK_CONTAINER(window), vbox);
+
+    label = gtk_label_new("Guess a number between 1 and 100");
+    gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
+
+    entry = gtk_entry_new();
+    gtk_box_pack_start(GTK_BOX(vbox), entry, FALSE, FALSE, 0);
+
+    GtkWidget *button = gtk_button_new_with_label("Guess");
+    g_signal_connect(button, "clicked", G_CALLBACK(on_guess_clicked), NULL);
+    gtk_box_pack_start(GTK_BOX(vbox), button, FALSE, FALSE, 0);
+
+    gtk_widget_show_all(window);
+    gtk_main();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add GTK-based GUI version `guess_gui.c`
- add README in `cGame` describing build instructions

## Testing
- `gcc randomStuff/cGame/guess.c -o randomStuff/cGame/guess`
- `gcc randomStuff/cGame/guess_gui.c -o randomStuff/cGame/guess_gui $(pkg-config --cflags --libs gtk+-3.0)` *(fails: Package 'gtk+-3.0' not found)*
- `./randomStuff/cGame/guess <<EOF
50
75
100
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684436db79908329aa14a171685b2f69