### PR TITLE
Add DeepSeek terminal chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ This repository contains various experiments and sample programs.
 ## Browser Game
 
 A simple Snake game is included under `HTML/snake`. Open `index.html` in a web browser to play.
+
+## DeepSeek Terminal Chat
+
+`deepseek_terminal.py` provides a small terminal chat client for the free
+[DeepSeek LLM](https://huggingface.co/deepseek-ai/deepseek-llm-7b-instruct)
+hosted on Hugging Face. To use it you need a Hugging Face API token stored in
+the environment variable `HUGGINGFACE_TOKEN`.
+
+Install the required dependency and run:
+
+```bash
+pip install requests
+python deepseek_terminal.py
+```
+
+Enter your prompts in the terminal and type `exit` to quit.

--- a/deepseek_terminal.py
+++ b/deepseek_terminal.py
@@ -1,0 +1,43 @@
+import os
+import requests
+
+# API endpoint for DeepSeek's public model hosted on Hugging Face
+API_URL = "https://api-inference.huggingface.co/models/deepseek-ai/deepseek-llm-7b-instruct"
+
+# Read the Hugging Face token from the environment, if provided
+HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+headers = {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}
+
+
+def query(prompt: str) -> str:
+    """Send a prompt to the model and return the generated text."""
+    payload = {"inputs": prompt}
+    response = requests.post(API_URL, headers=headers, json=payload)
+    response.raise_for_status()
+    data = response.json()
+
+    if isinstance(data, list) and data:
+        # Hugging Face Inference API for text-generation returns a list of dicts
+        return data[0].get("generated_text", "")
+    # Fallback in case of error or unexpected response
+    return str(data)
+
+
+def main() -> None:
+    print("DeepSeek Terminal Chat")
+    print("Type 'exit' to quit.\n")
+    while True:
+        user_input = input("You: ")
+        if user_input.strip().lower() == "exit":
+            break
+        try:
+            output = query(user_input)
+            print(f"AI: {output}\n")
+        except requests.HTTPError as err:
+            print(f"Request failed: {err}\n")
+        except Exception as ex:
+            print(f"Error: {ex}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `deepseek_terminal.py` example using the Hugging Face inference API
- document DeepSeek terminal chat usage in README

## Testing
- `python -m py_compile deepseek_terminal.py`
- `python deepseek_terminal.py <<'EOF'
exit
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6844b2a7b83083299d018848bfa2c058