### PR TITLE
Add Raspberry Pi camera streaming example

### DIFF
--- a/HTML/camera_feed.html
+++ b/HTML/camera_feed.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Raspberry Pi Camera Stream</title>
+</head>
+<body>
+    <h1>Live Camera Feed</h1>
+    <img src="/video_feed" width="640" height="480" />
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 ## Hello World
 
 Hey gang welcome to my crappy programs...
+
+## Raspberry Pi Camera Stream
+
+The `RasPi/camera/stream_server.py` script starts a small Flask server that
+provides an MJPEG stream from the Pi camera. The page `HTML/camera_feed.html`
+connects to this server and displays the live feed.
+
+### Usage
+1. Install the required packages:
+   ```bash
+   sudo apt install python3-flask python3-opencv
+   pip install picamera2
+   ```
+2. Run the server on the Raspberry Pi:
+   ```bash
+   python3 RasPi/camera/stream_server.py
+   ```
+3. Open a browser on the same network and navigate to
+   `http://<raspi-ip>:5000/` to see the live feed.

--- a/RasPi/camera/stream_server.py
+++ b/RasPi/camera/stream_server.py
@@ -1,0 +1,34 @@
+from flask import Flask, Response
+from picamera2 import Picamera2
+import cv2
+
+app = Flask(__name__, static_folder='../../HTML')
+
+camera = Picamera2()
+camera.configure(camera.create_video_configuration(main={"format": "RGB888", "size": (640, 480)}))
+camera.start()
+
+
+def gen_frames():
+    while True:
+        frame = camera.capture_array()
+        ret, buffer = cv2.imencode('.jpg', frame)
+        if not ret:
+            continue
+        frame_bytes = buffer.tobytes()
+        yield (b'--frame\r\n'
+               b'Content-Type: image/jpeg\r\n\r\n' + frame_bytes + b'\r\n')
+
+
+@app.route('/')
+def index():
+    return app.send_static_file('camera_feed.html')
+
+
+@app.route('/video_feed')
+def video_feed():
+    return Response(gen_frames(), mimetype='multipart/x-mixed-replace; boundary=frame')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add simple Flask streaming server for the Raspberry Pi camera
- create minimal HTML page that shows the video stream
- document how to run the streaming example

## Testing
- `pytest -q`
- `python3 -m py_compile RasPi/camera/stream_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6861a0cd6e288329b95bbe73e917e29e